### PR TITLE
fix: prevent stale ACEE pointer in ASXBSENV after racf_logout

### DIFF
--- a/src/racf/raclgout.c
+++ b/src/racf/raclgout.c
@@ -16,6 +16,7 @@ racf_logout(ACEE **acee)
     unsigned        *asxb       = (unsigned *)ascb[0x6C/4]; /* A(ASXB)      */
     ACEE            **asxbsenv  = (ACEE **)  &asxb[0xC8/4]; /* A(ASXBSENV)  */
     ACEE            *oldacee    = *asxbsenv;                /* prev ACEE    */
+    ACEE            *delacee;
     RACINIT         plist;
 
     /* lock the ASXB (ENQ) address */
@@ -52,8 +53,9 @@ racf_logout(ACEE **acee)
 "         MODESET KEY=ZERO,MODE=SUP\n" : : : "1", "14", "15");
     }
 
-    /* put this ACEE in ASXBSENV */
-    *asxbsenv = *acee;
+    /* put this ACEE in ASXBSENV for RACINIT DELETE */
+    delacee   = *acee;
+    *asxbsenv = delacee;
 
     __asm__("\n"
 "*\n"
@@ -62,12 +64,13 @@ racf_logout(ACEE **acee)
 "         RACINIT ENVIR=DELETE,ACEE=(%1),MF=(E,%2)\n"
 "         ST\t15,%0" : "=m"(rc) : "r"(acee), "m"(plist) : "1", "14", "15");
 
-    if (oldacee != *acee) {
-        /* restore previous ACEE in ASXBSENV */
-        *asxbsenv = oldacee;
+    if (oldacee == delacee) {
+        /* ASXBSENV pointed to the ACEE we just deleted — clear it */
+        *asxbsenv = (ACEE*)0;
     }
     else {
-        *asxbsenv = (ACEE*)0;
+        /* ASXBSENV was a different ACEE — restore it */
+        *asxbsenv = oldacee;
     }
 
     if (sup) {


### PR DESCRIPTION
Fixes #27

## Problem

`racf_logout()` compared `oldacee` (saved ASXBSENV) against `*acee` **after** `RACINIT DELETE`, which zeroes `*acee`. When `RACINIT CREATE` had previously anchored the same ACEE in ASXBSENV, the comparison `oldacee != *acee` always evaluated to TRUE, writing the freed pointer back into ASXBSENV.

This caused S0C4 abends in any subsequent code calling `racf_get_acee()` — observed in UFSD SSI router during Zowe Explorer file retrieval.

## Fix

Save `*acee` in `delacee` before `RACINIT DELETE` and compare `oldacee` against that stable value. When they match (ASXBSENV pointed to the deleted ACEE), ASXBSENV is cleared to NULL instead of restoring the freed pointer.

## Test plan

- [ ] Build crent370 on MVS (`make build && make link`)
- [ ] Start HTTPD + UFSD, retrieve two USS files via Zowe Explorer — no S0C4
- [ ] Verify FTP login/logout cycle leaves ASXBSENV clean (no stale pointer)