### PR TITLE
Add PDS member rename via STOW (SVC 21)

### DIFF
--- a/include/clibio.h
+++ b/include/clibio.h
@@ -164,4 +164,11 @@ extern int __dsalcf(char *ddname, const char *opts, ...);
 /* __dsfree() deallocate ddname */
 extern int __dsfree(const char *ddname);   /* input dd name                    */
 
+/* __renmem() rename PDS member oldmem to newmem in dsn via STOW change.
+ * Returns 0 on success, a positive STOW return code (8=old not found,
+ * 4=new already exists, ...), or a negative value for allocation/open
+ * failures.  Unlike rename(), which uses IDCAMS ALTER on a cataloged data
+ * set, this renames a member of a partitioned data set. */
+extern int __renmem(const char *dsn, const char *oldmem, const char *newmem);
+
 #endif

--- a/include/clibos.h
+++ b/include/clibos.h
@@ -51,6 +51,11 @@ struct bldl {
 /* __bldl() search for member in dcb or default link libraries when dcb is NULL */
 int __bldl(BLDL *bldl, void *dcb);
 
+/* __stow() maintain a PDS directory entry via STOW on an open DSORG=PO DCB.
+ * func is 'A' add, 'R' replace, 'D' delete or 'C' change (rename).
+ * Returns the STOW return code (0 on success) or -1 for an unknown function. */
+int __stow(void *dcb, void *area, int func);
+
 /* __cs() compare and swap in new_value to memory, returns old_value */
 unsigned __cs(void *mem, unsigned new_value);
 

--- a/src/clib/@@renmem.c
+++ b/src/clib/@@renmem.c
@@ -1,0 +1,85 @@
+/* @@RENMEM.C - rename a PDS member via STOW (change) */
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include "osio.h"
+#include "clibio.h"
+#include "clibos.h"
+
+/*
+ * __renmem() - rename member 'oldmem' to 'newmem' in PDS 'dsn'.
+ *
+ * Uses STOW change, so the member's TTR and directory user data (ISPF
+ * statistics) are preserved and no data is copied - this works for every
+ * record format including RECFM=U load modules.
+ *
+ * Returns:
+ *    0  success
+ *   >0  STOW return code (register 15), typically:
+ *          4  the new name already exists in the directory
+ *          8  the old name was not found in the directory
+ *         12  permanent I/O error
+ *         16  no space left in the directory
+ *         20  insufficient virtual storage
+ *   -1  invalid parameters or out of memory
+ *   -2  the data set could not be allocated (not found or in use)
+ *   -3  the data set could not be opened
+ */
+int
+__renmem(const char *dsn, const char *oldmem, const char *newmem)
+{
+    int   rc        = -1;
+    DCB   *dcb      = NULL;
+    char  ddname[9] = {0};
+    char  area[16];
+    int   i;
+
+    if (!dsn || !oldmem || !newmem) goto quit;
+    if (*oldmem <= ' ' || *newmem <= ' ') goto quit;
+
+    /* allocate the PDS DISP=SHR so we may update its directory */
+    if (__dsalcf(ddname, "DSN=%s;DISP=SHR", dsn)) {
+        rc = -2;
+        goto quit;
+    }
+
+    /* build a BSAM/BPAM DCB for the DD */
+    dcb = osbdcb(ddname, NULL);
+    if (!dcb) {
+        rc = -1;
+        goto dealloc;
+    }
+
+    /* force partitioned organisation: opening a PDS for OUTPUT with
+     * DSORG=PO updates the directory without erasing members, whereas
+     * DSORG=PS OUTPUT would reset the data set */
+    dcb->dcbdsrg1 = DCBDSGPO;
+    dcb->dcbdsrg2 = 0;
+
+    /* open for OUTPUT - STOW requires the data set open for output/update */
+    if (osbopen(dcb, 0, "write")) {
+        rc = -3;
+        goto close;
+    }
+
+    /* build the 16-byte STOW change list: old name (8) + new name (8),
+     * upper-cased and blank padded */
+    memset(area, ' ', sizeof(area));
+    for (i = 0; i < 8 && oldmem[i] > ' '; i++) {
+        area[i] = toupper((unsigned char)oldmem[i]);
+    }
+    for (i = 0; i < 8 && newmem[i] > ' '; i++) {
+        area[8 + i] = toupper((unsigned char)newmem[i]);
+    }
+
+    /* rename the directory entry (STOW change) */
+    rc = __stow(dcb, area, 'C');
+
+close:
+    osbclose(dcb, NULL, 1, 0);  /* close and free the DCB */
+    dcb = NULL;
+dealloc:
+    __dsfree(ddname);
+quit:
+    return rc;
+}

--- a/src/clib/@@stow.c
+++ b/src/clib/@@stow.c
@@ -1,0 +1,52 @@
+/* @@STOW.C - STOW (SVC 21) wrapper for PDS directory maintenance */
+#include <clibos.h>
+
+/*
+ * __stow() - update a partitioned data set directory entry.
+ *
+ * The DCB must be open for OUTPUT or UPDAT against a DSORG=PO data set.
+ * The directory action is selected by 'func':
+ *
+ *   'A' add      - area = 8-byte name + 3-byte TTR + 1-byte count + user data
+ *   'R' replace  - area = same layout as add
+ *   'D' delete   - area = 8-byte name
+ *   'C' change   - area = 8-byte old name + 8-byte new name (16 bytes);
+ *                  repoints the directory entry, preserving the member's
+ *                  TTR and user data (ISPF statistics)
+ *
+ * Returns the STOW return code in register 15 (0 on success, non-zero
+ * otherwise - see the STOW documentation), or -1 for an unknown function.
+ *
+ * The assembler STOW macro encodes the function and SVC linkage, so the
+ * register conventions are handled the same way __bldl() wraps BLDL.
+ */
+int
+__stow(void *dcb, void *area, int func)
+{
+    int rc = -1;
+
+    switch (func) {
+    case 'A': case 'a':
+        __asm__("STOW\t(%1),(%2),A\n\t"
+                "LR\t%0,R15"
+                : "=r"(rc) : "r"(dcb), "r"(area) : "0", "1", "14", "15");
+        break;
+    case 'R': case 'r':
+        __asm__("STOW\t(%1),(%2),R\n\t"
+                "LR\t%0,R15"
+                : "=r"(rc) : "r"(dcb), "r"(area) : "0", "1", "14", "15");
+        break;
+    case 'D': case 'd':
+        __asm__("STOW\t(%1),(%2),D\n\t"
+                "LR\t%0,R15"
+                : "=r"(rc) : "r"(dcb), "r"(area) : "0", "1", "14", "15");
+        break;
+    case 'C': case 'c':
+        __asm__("STOW\t(%1),(%2),C\n\t"
+                "LR\t%0,R15"
+                : "=r"(rc) : "r"(dcb), "r"(area) : "0", "1", "14", "15");
+        break;
+    }
+
+    return rc;
+}


### PR DESCRIPTION
## Summary

Adds a PDS **member rename** primitive using `STOW` (SVC 21), as requested
in #35.

`rename()` (`src/clib/rename.c`) uses IDCAMS `ALTER ... NEWNAME(...)`, which
renames a cataloged *data set* but cannot rename a *member* of a PDS. This PR
fills that gap.

## Changes

- **`src/clib/@@stow.c`** — `__stow(void *dcb, void *area, int func)`: a thin
  `STOW` wrapper for directory maintenance (`A` add / `R` replace / `D` delete /
  `C` change), mirroring how `@@bldl.c` wraps `BLDL`. Returns the STOW R15.
- **`src/clib/@@renmem.c`** — `__renmem(dsn, oldmem, newmem)`: allocates the PDS
  `DISP=SHR`, opens a `DSORG=PO` DCB for `OUTPUT`, and issues `STOW ...,C` to
  rename the directory entry.
- **`include/clibos.h`** — declare `__stow()`.
- **`include/clibio.h`** — declare `__renmem()` next to `rename()`.

## Why STOW change

`STOW C` repoints the directory entry to the existing TTR, so:

- the member's **TTR and directory user data (ISPF statistics) are preserved**,
- the operation is **atomic**, uses **no extra space**,
- it works for **every RECFM including U** (load modules),

unlike a copy-and-delete approach.

## Design notes

- The DCB is built by the existing `osbdcb()` and then forced to partitioned
  organisation (`dcbdsrg1 = DCBDSGPO`). `DSORG=PO` is essential: opening a PDS
  for `OUTPUT` with `DSORG=PO` updates the directory without erasing members,
  whereas `DSORG=PS` `OUTPUT` would reset the data set. `osbopen()` only touches
  MACRF/the OPEN parameter list, so the PO organisation survives to `OPEN`.
- `osbopen()` wraps `OPEN` in `try()`, so an unexpected target (e.g. a
  sequential data set, S013) fails as a caught abend → `__renmem()` returns `-3`
  rather than risking data loss.
- The model-DCB-into-dynamic-storage idiom follows `osbdcb()` / `@@cpopen.c`;
  the `STOW`/`BLDL` register-operand form is confirmed against the local
  `sysmac/bldl.macro` and `sysmac/find.macro` (both load operands via
  `IHBINNRA`, which accepts `(reg)` notation).

## Return codes

`__renmem()` returns `0` on success, a positive STOW return code (e.g. `8` old
name not found, `4` new name already exists), or a negative value for
allocation/open failures. The exact STOW codes should be confirmed against the
OS manual when mapping to HTTP status in the consumer.

## Testing

Both modules cross-compile and **assemble + NCAL link cleanly on MVSCE in CI
(`@@STOW` RC=0, `@@RENMEM` RC=0)**. The runtime behaviour (STOW SVC, OPEN/CLOSE,
dynamic allocation) still needs a functional run on MVS 3.8j. Suggested manual
checks:

- rename an existing member → success, content + stats preserved
- rename a non-existent member → STOW RC 8
- rename onto an existing member name → STOW RC 4
- rename a load module member (RECFM=U) in a LOAD/LINKLIB → still loadable

## Consumer

mvsMF `memberPutHandler` (mvslovers/mvsmf#125, Zowe Explorer member rename) will
call `__renmem()` once this is released and the crent370 dependency is bumped.

Closes #35
